### PR TITLE
provide a scaling factor to make orders easier to place

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ Whether or not the coinbase sandbox should be used.
 
 `ORDERS`
 
-"Hash of orders that you wish to place. Must be of the form`{\"orders\": []}`
+"Hash of orders that you wish to place. Must be of the form`{\"<order_type>\": []}`
 
-Each buy can be made up of multiple orders, which must be of the form
+Each buy/sell can be made up of multiple orders, which must be of the form
 
 ```
 {


### PR DESCRIPTION
Adds a new `scale` param which will allow operators to provide a constant scaling factor over _all_ orders. 

This is useful if a user wants to buy equivalent amounts of _multiple_ assets. 